### PR TITLE
attemptsの有効化

### DIFF
--- a/lib/Net/DNS/Lite.pm
+++ b/lib/Net/DNS/Lite.pm
@@ -381,6 +381,7 @@ sub parse_resolv_conf {
     $self->{search} = [];
 
     my $attempts;
+    my $timeout;
 
     for (split /\n/, $resolvconf) {
         s/\s*[;#].*$//; # not quite legal, but many people insist
@@ -401,7 +402,7 @@ sub parse_resolv_conf {
         } elsif (/^\s*options\s+(.*?)\s*$/i) {
             for (split /\s+/, $1) {
                 if (/^timeout:(\d+)$/) {
-                    $self->{timeout} = [$1];
+                    $timeout = $1;
                 } elsif (/^attempts:(\d+)$/) {
                     $attempts = $1;
                 } elsif (/^ndots:(\d+)$/) {
@@ -411,6 +412,12 @@ sub parse_resolv_conf {
                 }
             }
         }
+    }
+
+    if ( $timeout || $attempts ) {
+        $timeout ||= 5;
+        $attempts ||= 2;
+        $self->{timeout} = [ map { $timeout } 1..$attempts ];
     }
 }
 

--- a/t/04resolv_conf.t
+++ b/t/04resolv_conf.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use Net::DNS::Lite;
+use Test::More;
+
+my $r = Net::DNS::Lite->new();
+
+{
+    $r->parse_resolv_conf(<<EOF);
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+EOF
+    is_deeply $r->{server}, [qw/8.8.8.8 8.8.4.4/];
+    is_deeply $r->{timeout}, [2,5,5];
+}
+
+{
+    $r->parse_resolv_conf(<<EOF);
+options rotate timeout:1
+nameserver 8.8.8.8
+EOF
+    is_deeply $r->{timeout}, [1,1];
+}
+
+{
+    $r->parse_resolv_conf(<<EOF);
+options rotate attempts:3
+nameserver 8.8.8.8
+EOF
+    is_deeply $r->{timeout}, [5,5,5];
+}
+
+{
+    $r->parse_resolv_conf(<<EOF);
+options rotate timeout:2 attempts:3
+nameserver 8.8.8.8
+EOF
+    is_deeply $r->{timeout}, [2,2,2];
+}
+
+done_testing();
+
+


### PR DESCRIPTION
resolv.confでoptions timeoutだけ指定するとretryしなくなってしまうので、attemptsも動くようにしたいです

デフォルトのtimeoutが[2,5,5]なのが標準的なresolv.confの動作と異なってしまいますが、いきなり動作が変わるのもよくないと思ったので、resolv.confにtimeout:\dかattempts:\dがあった時だけ動作が変更されるようにしました。
