### PR TITLE
Skip tests that require network access if not available

### DIFF
--- a/t/00base.t
+++ b/t/00base.t
@@ -4,6 +4,9 @@ use warnings;
 use Test::More;
 
 BEGIN {
+    plan skip_all => 'These tests need network access'
+        if $ENV{NO_NETWORK_TESTING};
+
     use_ok('Net::DNS::Lite');
 };
 

--- a/t/01no_response.t
+++ b/t/01no_response.t
@@ -6,6 +6,11 @@ use Net::DNS::Lite;
 use Test::More;
 use Time::HiRes qw(time);
 
+BEGIN {
+    plan skip_all => 'These tests need network access'
+        if $ENV{NO_NETWORK_TESTING};
+}
+
 my $r = Net::DNS::Lite->new(
     server => [ qw(google.com) ], # google.com just drops UDP 53 (no response)
 );

--- a/t/02inet_aton.t
+++ b/t/02inet_aton.t
@@ -7,6 +7,9 @@ use Test::More;
 use Time::HiRes qw(time);
 
 BEGIN {
+    plan skip_all => 'These tests need network access'
+        if $ENV{NO_NETWORK_TESTING};
+
     if (! -e '/etc/resolv.conf') {
         plan skip_all => 'no /etc/resolv.conf';
     }

--- a/t/03cache.t
+++ b/t/03cache.t
@@ -6,6 +6,9 @@ use Test::More;
 use Test::Requires qw(Cache::LRU);
 
 BEGIN {
+    plan skip_all => 'These tests need network access'
+        if $ENV{NO_NETWORK_TESTING};
+
     use_ok('Net::DNS::Lite');
 };
 

--- a/t/05mx.t
+++ b/t/05mx.t
@@ -4,6 +4,9 @@ use warnings;
 use Test::More;
 
 BEGIN {
+    plan skip_all => 'These tests need network access'
+        if $ENV{NO_NETWORK_TESTING};
+
     use_ok('Net::DNS::Lite');
 };
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Net-DNS-Lite.
We thought you might be interested in it too.

    Description: Skip tests that require network access if not available
    Author: Alex Muntada <alexm@alexm.org>

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libnet-dns-lite-perl.git/plain/debian/patches/no-network-tests.patch

Thanks for considering,
  Alex Muntada,
  Debian Perl Group
